### PR TITLE
Fixed an issue where VS failed to build bladebit due to CJK codepage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,6 +149,7 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
         /wd4514
         /wd4626
         /wd5027
+        /wd4819
         /DUNICODE=1
         /DWIN32_LEAN_AND_MEAN=1
         /DNOMINMAX=1


### PR DESCRIPTION
Building with VisualStudio 2022 with windows system codepage set to cp932(Japanese/SJIS) which is the default codepage for Japanese locale failed due to a bunch of C4819 warnings:
`Warning C4819: The file contains a character that cannot be represented in the current code page (932). Save the file in Unicode format to prevent data loss`
I managed to success building by suppressing C4819 warning.
