### PR TITLE
Add sleep command to pause plotting for N seconds after writing plot

### DIFF
--- a/Harvester.cmake
+++ b/Harvester.cmake
@@ -129,7 +129,7 @@ target_link_libraries(bladebit_harvester PRIVATE
     bladebit_config 
     Threads::Threads
 
-    $<${have_cuda}: CUDA::cudart_static>
+    $<${have_cuda}:CUDA::cudart_static>
 
     INTERFACE
         $<$<PLATFORM_ID:Linux>:

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -139,6 +139,12 @@ int main( int argc, const char* argv[] )
         req.IsFinalPlot  = i == plotCount-1;
 
         plotter->Run( req );
+
+        if( cfg.sleepSeconds )
+        {
+            Log::Line( "Sleeping for %u seconds", cfg.sleepSeconds );
+            sleep(cfg.sleepSeconds);
+        }
     }
 }
 
@@ -159,6 +165,8 @@ void ParseCommandLine( GlobalPlotConfig& cfg, IPlotter*& outPlotter, int argc, c
         if( cli.ReadU32( cfg.threadCount, "-t", "--threads" ) )
             continue;
         else if( cli.ReadU32( cfg.plotCount, "-n", "--count" ) )
+            continue;
+        else if( cli.ReadU32( cfg.sleepSeconds, "-s", "--sleep" ) )
             continue;
         else if( cli.ReadStr( farmerPublicKey, "-f", "--farmer-key" ) )
             continue;
@@ -459,6 +467,7 @@ void ParseCommandLine( GlobalPlotConfig& cfg, IPlotter*& outPlotter, int argc, c
         Log::Line( " Will create %u plots.", cfg.plotCount );
 
     Log::Line( " Thread count          : %d", cfg.threadCount );
+    Log::Line( " Sleep seconds per plot: %d", cfg.sleepSeconds );
     Log::Line( " Warm start enabled    : %s", cfg.warmStart ? "true" : "false" );
     Log::Line( " NUMA disabled         : %s", cfg.disableNuma ? "true" : "false" );
     Log::Line( " CPU affinity disabled : %s", cfg.disableCpuAffinity ? "true" : "false" );
@@ -583,6 +592,8 @@ R"(
                         instances of Bladebit as you can manually
                         assign thread affinity yourself when launching Bladebit.
  
+ -s, --sleep          : Number of seconds to sleep after each plot is generated
+
  --memory             : Display system memory available, in bytes, and the 
                         required memory to run Bladebit, in bytes.
  

--- a/src/plotting/GlobalPlotConfig.h
+++ b/src/plotting/GlobalPlotConfig.h
@@ -12,6 +12,7 @@ struct GlobalPlotConfig
 {
     uint32 threadCount   = 0;
     uint32 plotCount     = 1;
+    uint32 sleepSeconds  = 0;
 
     const char* plotIdStr    = nullptr;
     const char* plotMemoStr  = nullptr;


### PR DESCRIPTION
Hey team,

After fussing around with my plotting setup for awhile since the cuda alpha was released, I realized that I could dramatically increase my throughput by sleeping for a few seconds after each plot to allow my copy process to get a head start to limit thrashing on the plot SSD.

This has worked great for me and wanted to see if you were in interested in adding this to the official build.

Currently doesn't support Windows (I see `windows.h` isn't included at global scope for bug reasons, but since I use `sleep` in `main.cpp`, I assume including it there would be just as bad). Also don't have a Windows machine myself, so testing on my end is limited.

Mostly just trying to get this on your radar to judge whether you think others would find this feature useful and happy to make any and all changes to conform to your standards.

Thanks again for your hard work!