### PR TITLE
Change GreenReaper target to be static lib by default

### DIFF
--- a/.github/actions/build-harvester.sh
+++ b/.github/actions/build-harvester.sh
@@ -46,7 +46,7 @@ mkdir -p build-harvester
 pushd build-harvester
 cmake .. -DCMAKE_BUILD_TYPE=Release -DBB_HARVESTER_ONLY=ON
 
-cmake --build . --config Release --target bladebit_harvester -j$procs
+cmake --build . --config Release --target bladebit_harvester --target bladebit_harvester_dynamic -j$procs
 cmake --install . --prefix harvester_dist
 
 pushd harvester_dist/green_reaper

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -199,6 +199,35 @@ jobs:
           path: ${{ env.harvester_artifact_path }}
           if-no-files-found: error
 
+  build-harvester-macos-x86-64:
+    runs-on: macOS-11
+    steps:
+      - name: Cleanup Environment
+        uses: Chia-Network/actions/clean-workspace@main
+
+      - name: Checkout Repo
+        uses: actions/checkout@v3
+
+      - name: Get Version Number
+        id: version_number
+        run: bash -e .github/actions/get-version.sh macos x86-64
+
+      - name: Build Harvester
+        shell: bash
+        run: |
+          export artifact_name="green_reaper-v${{ env.BB_VERSION }}-macos-x86-64.tar.gz"
+          echo "harvester_artifact_name=${artifact_name}" >> "$GITHUB_ENV"
+          # emits env.harvester_artifact_path
+          bash .github/actions/build-harvester.sh --artifact "${artifact_name}"
+
+      - name: Upload Harvester Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ env.harvester_artifact_name }}.zip
+          path: ${{ env.harvester_artifact_path }}
+          if-no-files-found: error
+
+
   build-bladebit-ubuntu-x86-64:
     runs-on: ubuntu-20.04
     steps:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,10 +98,10 @@ find_package(Threads REQUIRED)
 if(NOT ${BB_HARVESTER_ONLY})
     # BLS
     FetchContent_Declare(
-    bls
-    GIT_REPOSITORY https://github.com/Chia-Network/bls-signatures.git
-    GIT_TAG        1.0.10
-    EXCLUDE_FROM_ALL ${BB_IS_DEPENDENCY}
+        bls
+        GIT_REPOSITORY https://github.com/Chia-Network/bls-signatures.git
+        GIT_TAG        1.0.10
+        EXCLUDE_FROM_ALL ${BB_IS_DEPENDENCY}
     )
 
     set(BUILD_BLS_PYTHON_BINDINGS "0" CACHE STRING "0")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,7 +85,6 @@ option(BB_ENABLE_TESTS "Enable tests." OFF)
 option(NO_CUDA_HARVESTER "Explicitly disable CUDA in the bladebit_harvester target." OFF)
 option(BB_NO_EMBED_VERSION "Disable embedding the version when building locally (non-CI)." ON)
 option(BB_HARVESTER_ONLY "Enable only the harvester target." OFF)
-option(BB_HARVESTER_STATIC "Build the harvester target as a static library." OFF)
 
 
 #

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,6 +85,7 @@ option(BB_ENABLE_TESTS "Enable tests." OFF)
 option(NO_CUDA_HARVESTER "Explicitly disable CUDA in the bladebit_harvester target." OFF)
 option(BB_NO_EMBED_VERSION "Disable embedding the version when building locally (non-CI)." ON)
 option(BB_HARVESTER_ONLY "Enable only the harvester target." OFF)
+option(BB_HARVESTER_STATIC "Build the harvester target as a static library." OFF)
 
 
 #

--- a/Harvester.cmake
+++ b/Harvester.cmake
@@ -1,5 +1,10 @@
-add_library(bladebit_harvester $<$<BOOL:${BB_HARVESTER_STATIC}>:SHARED>
+if(${BB_HARVESTER_STATIC})
+    add_library(bladebit_harvester STATIC)
+else()
+    add_library(bladebit_harvester SHARED)
+endif()
 
+target_sources(bladebit_harvester
     src/pch.cpp
 
     src/pos/chacha8.cpp

--- a/Harvester.cmake
+++ b/Harvester.cmake
@@ -4,7 +4,7 @@ else()
     add_library(bladebit_harvester SHARED)
 endif()
 
-target_sources(bladebit_harvester PUBLIC
+target_sources(bladebit_harvester PRIVATE
     src/pch.cpp
 
     src/pos/chacha8.cpp

--- a/Harvester.cmake
+++ b/Harvester.cmake
@@ -114,9 +114,11 @@ target_compile_features(bladebit_harvester PRIVATE cxx_std_17)
 
 target_compile_definitions(bladebit_harvester PRIVATE
     BB_IS_HARVESTER=1
-    BB_CUDA_ENABLED=1
     THRUST_IGNORE_CUB_VERSION_CHECK=1
     GR_EXPORT=1
+    $<${have_cuda}:
+        BB_CUDA_ENABLED=1
+    >
 )
 
 target_compile_options(bladebit_harvester PRIVATE 

--- a/Harvester.cmake
+++ b/Harvester.cmake
@@ -4,7 +4,7 @@ else()
     add_library(bladebit_harvester SHARED)
 endif()
 
-target_sources(bladebit_harvester
+target_sources(bladebit_harvester PUBLIC
     src/pch.cpp
 
     src/pos/chacha8.cpp

--- a/Harvester.cmake
+++ b/Harvester.cmake
@@ -1,6 +1,4 @@
-add_library(bladebit_harvester 
-    $<$<BOOL:${BB_HARVESTER_STATIC}>:SHARED>
-
+add_library(bladebit_harvester $<$<BOOL:${BB_HARVESTER_STATIC}>:SHARED>
 
     src/pch.cpp
 

--- a/Harvester.cmake
+++ b/Harvester.cmake
@@ -1,4 +1,6 @@
-add_library(bladebit_harvester SHARED
+add_library(bladebit_harvester 
+    $<$<BOOL:${BB_HARVESTER_STATIC}>:SHARED>
+
 
     src/pch.cpp
 


### PR DESCRIPTION

- Add in CPU-only macOS harvesting at the build level.
- GreenReaper DLL target also available as a separate one from the static one.