### PR TITLE
Make fatlib

### DIFF
--- a/Config.cmake
+++ b/Config.cmake
@@ -129,16 +129,43 @@ cmake_policy(SET CMP0105 NEW)
 set(cuda_archs
 
     $<${is_cuda_release}:
-        -gencode=arch=compute_52,code=sm_52 # Maxwell
-        -gencode=arch=compute_61,code=sm_61 # Pascal
-        -gencode=arch=compute_70,code=sm_70 # Volta
-        -gencode=arch=compute_86,code=sm_86 # Ampere
-        -gencode=arch=compute_87,code=sm_87 # Orin
-        -gencode=arch=compute_89,code=sm_89 # Ada
+## Maxwell
+    ## Tesla/Quadro M series
+        -gencode=arch=compute_50,code=sm_50
+    ## Quadro M6000 , GeForce 900, GTX-970, GTX-980, GTX Titan X
+        # -gencode=arch=compute_52,code=sm_52
+    ## Tegra (Jetson) TX1 / Tegra X1, Drive CX, Drive PX, Jetson Nano
+        -gencode=arch=compute_53,code=sm_53
+## Pascal
+    ## GeForce 1000 series
+        -gencode=arch=compute_60,code=sm_60
+    ## GeForce GTX 1050Ti, GTX 1060, GTX 1070, GTX 1080
+        # -gencode=arch=compute_61,code=sm_61
+    ## Drive Xavier, Jetson AGX Xavier, Jetson Xavier NX
+        # -gencode=arch=compute_62,code=sm_62
+## Volta
+    ## GV100, Tesla V100, Titan V
+        -gencode=arch=compute_70,code=sm_70
+    ## Tesla V100
+        # -gencode=arch=compute_72,code=sm_72
+    ## Turing
+        -gencode=arch=compute_75,code=sm_75
+## Ampere
+    ## GeForce RTX 3000 series, NVIDIA A100
+        -gencode=arch=compute_86,code=sm_86
+    ## Jetson Orin
+        -gencode=arch=compute_87,code=sm_87
+## Lovelace
+    ## NVIDIA GeForce RTX 4090, RTX 4080, RTX 6000, Tesla L40
+        -gencode=arch=compute_89,code=sm_89
+## Hopper
+    ## NVIDIA H100 (GH100)
+        # -gencode=arch=compute_90,code=sm_90
+        # -gencode=arch=compute_90a,code=sm_90a
     >
 
     $<${is_cuda_debug}:
         -arch=native
-        # -gencode=arch=compute_52,code=sm_52 # Maxwell
+        # -gencode=arch=compute_52,code=sm_50 # Maxwell
     >
 )

--- a/Config.cmake
+++ b/Config.cmake
@@ -127,31 +127,32 @@ set(preinclude_pch
 cmake_policy(SET CMP0105 NEW)
 
 set(cuda_archs
-
     $<${is_cuda_release}:
 ## Maxwell
     ## Tesla/Quadro M series
         -gencode=arch=compute_50,code=sm_50
     ## Quadro M6000 , GeForce 900, GTX-970, GTX-980, GTX Titan X
-        # -gencode=arch=compute_52,code=sm_52
+        -gencode=arch=compute_52,code=sm_52
     ## Tegra (Jetson) TX1 / Tegra X1, Drive CX, Drive PX, Jetson Nano
         -gencode=arch=compute_53,code=sm_53
 ## Pascal
     ## GeForce 1000 series
         -gencode=arch=compute_60,code=sm_60
     ## GeForce GTX 1050Ti, GTX 1060, GTX 1070, GTX 1080
-        # -gencode=arch=compute_61,code=sm_61
+        -gencode=arch=compute_61,code=sm_61
     ## Drive Xavier, Jetson AGX Xavier, Jetson Xavier NX
-        # -gencode=arch=compute_62,code=sm_62
+        -gencode=arch=compute_62,code=sm_62
 ## Volta
     ## GV100, Tesla V100, Titan V
         -gencode=arch=compute_70,code=sm_70
     ## Tesla V100
-        # -gencode=arch=compute_72,code=sm_72
+        -gencode=arch=compute_72,code=sm_72
     ## Turing
         -gencode=arch=compute_75,code=sm_75
 ## Ampere
-    ## GeForce RTX 3000 series, NVIDIA A100
+    ## NVIDIA DGX-A100
+       -gencode=arch=compute_80,code=sm_80
+    ## GeForce RTX 3000 series
         -gencode=arch=compute_86,code=sm_86
     ## Jetson Orin
         -gencode=arch=compute_87,code=sm_87

--- a/Config.cmake
+++ b/Config.cmake
@@ -127,6 +127,7 @@ set(preinclude_pch
 cmake_policy(SET CMP0105 NEW)
 
 set(cuda_archs
+
     $<${is_cuda_release}:
 ## Maxwell
     ## Tesla/Quadro M series
@@ -150,15 +151,17 @@ set(cuda_archs
     ## Turing
         -gencode=arch=compute_75,code=sm_75
 ## Ampere
-    ## NVIDIA DGX-A100
-       -gencode=arch=compute_80,code=sm_80
-    ## GeForce RTX 3000 series
+    ## NVIDIA A100, DGX-A100
+        -gencode=arch=compute_80,code=sm_80
+    ## GeForce RTX 3000 series, NVIDIA A100
         -gencode=arch=compute_86,code=sm_86
     ## Jetson Orin
         -gencode=arch=compute_87,code=sm_87
 ## Lovelace
     ## NVIDIA GeForce RTX 4090, RTX 4080, RTX 6000, Tesla L40
         -gencode=arch=compute_89,code=sm_89
+    ## Future proofing
+        -gencode=arch=compute_89,code=compute_89
 ## Hopper
     ## NVIDIA H100 (GH100)
         # -gencode=arch=compute_90,code=sm_90
@@ -167,6 +170,6 @@ set(cuda_archs
 
     $<${is_cuda_debug}:
         -arch=native
-        # -gencode=arch=compute_52,code=sm_50 # Maxwell
+        # -gencode=arch=compute_52,code=sm_52 # Maxwell
     >
 )

--- a/Harvester.cmake
+++ b/Harvester.cmake
@@ -1,5 +1,3 @@
-set(CMAKE_CUDA_ARCHITECTURES "50;52;53;60;61;62;70;72;75;80;86;87;89")
-
 if(NOT ${BB_HARVESTER_STATIC})
     add_library(bladebit_harvester SHARED)
 else()
@@ -139,10 +137,10 @@ target_compile_definitions(bladebit_harvester
 
 target_compile_options(bladebit_harvester PRIVATE 
     ${preinclude_pch}
-    # $<${have_cuda}:${cuda_archs}>
+    ${cuda_archs}
 )
 
-if(${have_cuda})
+if(have_cuda)
     target_link_options(bladebit_harvester PUBLIC $<DEVICE_LINK: ${cuda_archs}>)
 endif()
 

--- a/Harvester.cmake
+++ b/Harvester.cmake
@@ -1,3 +1,8 @@
+foreach(ARCH IN LISTS BB_CUDA_GENCODE_ARCHS)
+  set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -gencode arch=compute_${ARCH},code=sm_${ARCH}")
+endforeach()
+
+
 if(NOT ${BB_HARVESTER_STATIC})
     add_library(bladebit_harvester SHARED)
 else()

--- a/Harvester.cmake
+++ b/Harvester.cmake
@@ -1,7 +1,4 @@
-foreach(ARCH IN LISTS BB_CUDA_GENCODE_ARCHS)
-  set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -gencode arch=compute_${ARCH},code=sm_${ARCH}")
-endforeach()
-
+set(CMAKE_CUDA_ARCHITECTURES "50;52;53;60;61;62;70;72;75;80;86;87;89")
 
 if(NOT ${BB_HARVESTER_STATIC})
     add_library(bladebit_harvester SHARED)


### PR DESCRIPTION
If we set `CMAKE_CUDA_ARCHITECTURES OFF`, this _will generate PTX only for the lowest supported compute capability, and SASS will be generated by the driver JIT for the actual GPU on the user's system at runtime. This may not be what you want if you're distributing precompiled binaries and want them to be runnable out of the box on all supported GPUs._