### PR TITLE
Adding windows build support

### DIFF
--- a/cmake_modules/EmbedVersion.cmake
+++ b/cmake_modules/EmbedVersion.cmake
@@ -5,15 +5,17 @@ if((NOT DEFINED ENV{CI}) AND (NOT DEFINED CACHE{bb_version_embedded}))
     set(bb_version_embedded on CACHE BOOL "Version embedding has already happened.")
 
     set(cmd_ver bash)
+    set(ext_ver sh)
     if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
-        set(cmd_ver bash.exe)
+        set(cmd_ver pwsh)
+        set(ext_ver ps1)
     endif()
 
-    execute_process(COMMAND ${cmd_ver} ${CMAKE_SOURCE_DIR}/extract-version.sh major    OUTPUT_VARIABLE bb_ver_maj    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} COMMAND_ERROR_IS_FATAL ANY)
-    execute_process(COMMAND ${cmd_ver} ${CMAKE_SOURCE_DIR}/extract-version.sh minor    OUTPUT_VARIABLE bb_ver_min    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} COMMAND_ERROR_IS_FATAL ANY)
-    execute_process(COMMAND ${cmd_ver} ${CMAKE_SOURCE_DIR}/extract-version.sh revision OUTPUT_VARIABLE bb_ver_rev    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} COMMAND_ERROR_IS_FATAL ANY)
-    execute_process(COMMAND ${cmd_ver} ${CMAKE_SOURCE_DIR}/extract-version.sh suffix   OUTPUT_VARIABLE bb_ver_suffix WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} COMMAND_ERROR_IS_FATAL ANY)
-    execute_process(COMMAND ${cmd_ver} ${CMAKE_SOURCE_DIR}/extract-version.sh commit   OUTPUT_VARIABLE bb_ver_commit WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} COMMAND_ERROR_IS_FATAL ANY)
+    execute_process(COMMAND ${cmd_ver} ${CMAKE_SOURCE_DIR}/extract-version.${ext_ver} major    OUTPUT_VARIABLE bb_ver_maj    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} COMMAND_ERROR_IS_FATAL ANY)
+    execute_process(COMMAND ${cmd_ver} ${CMAKE_SOURCE_DIR}/extract-version.${ext_ver} minor    OUTPUT_VARIABLE bb_ver_min    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} COMMAND_ERROR_IS_FATAL ANY)
+    execute_process(COMMAND ${cmd_ver} ${CMAKE_SOURCE_DIR}/extract-version.${ext_ver} revision OUTPUT_VARIABLE bb_ver_rev    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} COMMAND_ERROR_IS_FATAL ANY)
+    execute_process(COMMAND ${cmd_ver} ${CMAKE_SOURCE_DIR}/extract-version.${ext_ver} suffix   OUTPUT_VARIABLE bb_ver_suffix WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} COMMAND_ERROR_IS_FATAL ANY)
+    execute_process(COMMAND ${cmd_ver} ${CMAKE_SOURCE_DIR}/extract-version.${ext_ver} commit   OUTPUT_VARIABLE bb_ver_commit WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} COMMAND_ERROR_IS_FATAL ANY)
 
     # Remove trailing whitespace incurred in windows gitbash
     string(STRIP "${bb_ver_maj}"    bb_ver_maj)

--- a/extract-version.ps1
+++ b/extract-version.ps1
@@ -1,0 +1,60 @@
+# Navigate to the script's directory
+$scriptPath = Split-Path -Path $MyInvocation.MyCommand.Definition -Parent
+Set-Location -Path $scriptPath
+
+# Arguments
+$ver_component = $args[0]  # The user-specified component from the full version
+
+# Read the version from the file
+$version_str = (Get-Content 'VERSION' | Select-Object -First 1 | Out-String).Trim()
+$bb_version_suffix = (Get-Content 'VERSION' | Select-Object -Last 1 | Out-String).Trim()
+$version_header = 'src\Version.h'
+
+if ($version_str -eq $bb_version_suffix) {
+    $bb_version_suffix = ""
+}
+
+# Prepend a '-' to the suffix, if necessary
+if (-Not [string]::IsNullOrEmpty($bb_version_suffix) -and $bb_version_suffix[0] -ne '-') {
+    $bb_version_suffix = "-$bb_version_suffix"
+}
+
+# Parse the major, minor, and revision numbers
+$bb_ver_maj, $bb_ver_min, $bb_ver_rev = $version_str -split '\.' | ForEach-Object { $_.Trim() }
+
+# Get the Git commit hash
+$bb_git_commit = $env:GITHUB_SHA
+if ([string]::IsNullOrEmpty($bb_git_commit)) {
+    $bb_git_commit = & git rev-parse HEAD
+}
+
+if ([string]::IsNullOrEmpty($bb_git_commit)) {
+    $bb_git_commit = "unknown"
+}
+
+# Check if the user wants a specific component
+if (-Not [string]::IsNullOrEmpty($ver_component)) {
+    switch ($ver_component) {
+        "major" {
+            Write-Host -NoNewline $bb_ver_maj
+        }
+        "minor" {
+            Write-Host -NoNewline $bb_ver_min
+        }
+        "revision" {
+            Write-Host -NoNewline $bb_ver_rev
+        }
+        "suffix" {
+            Write-Host -NoNewline $bb_version_suffix
+        }
+        "commit" {
+            Write-Host -NoNewline $bb_git_commit
+        }
+        default {
+            Write-Error "Invalid version component '$ver_component'"
+            exit 1
+        }
+    }
+    exit 0
+}
+


### PR DESCRIPTION
```
-- Found Threads: TRUE
-- The ASM_MASM compiler identification is MSVC
-- Found assembler: C:/Program Files/Microsoft Visual Studio/2022/Community/VC/Tools/MSVC/14.32.31326/bin/Hostx64/x64/ml64.exe
-- Build python bindings: 0
-- Build tests: 0
-- Build benchmarks: 0
-- blst will be built from: 6b837a0921cf41e501faaee1976a4035ae29d893 and repository https://github.com/supranational/blst.git
Embedding local build version
The file cannot be accessed by the system.
CMake Error at cmake_modules/EmbedVersion.cmake:12 (execute_process):
  execute_process failed command indexes:

    1: "Child return code: 1"

Call Stack (most recent call first):
  CMakeLists.txt:149 (include)


-- Configuring incomplete, errors occurred!
```
This fixes this issue when building on windows